### PR TITLE
Make FSPinBox::get{Prefix,Suffix} functions inline

### DIFF
--- a/src/include/final/fspinbox.h
+++ b/src/include/final/fspinbox.h
@@ -164,11 +164,11 @@ inline sInt64 FSpinBox::getValue()
 { return value; }
 
 //----------------------------------------------------------------------
-FString FSpinBox::getPrefix() const
+inline FString FSpinBox::getPrefix() const
 { return pfix; }
 
 //----------------------------------------------------------------------
-FString FSpinBox::getSuffix() const
+inline FString FSpinBox::getSuffix() const
 { return sfix; }
 
 //----------------------------------------------------------------------


### PR DESCRIPTION
Otherwise, if more than one file includes the header, we will have
duplicate symbols during link time.