### PR TITLE
Fixed fMenuBar. Left arraw doesn't restore terminal redrawing.

### DIFF
--- a/src/fmenubar.cpp
+++ b/src/fmenubar.cpp
@@ -398,7 +398,7 @@ bool FMenuBar::selectPrevItem()
 
       setSelectedItem(prev);
       redraw();
-      setTerminalUpdates (FVTerm::stop_terminal_updates);
+      setTerminalUpdates (FVTerm::start_terminal_updates);
       break;
     }
   }


### PR DESCRIPTION
The misprint in fmenubar.cpp in method selectPrevItem never redraw terminal.