### PR TITLE
FString string_view support, TextView member visibility

### DIFF
--- a/final/util/fstring.cpp
+++ b/final/util/fstring.cpp
@@ -100,6 +100,15 @@ FString::FString (const std::string& s)
 }
 
 //----------------------------------------------------------------------
+#if __cplusplus >= 201703L
+FString::FString (const std::string_view& s)
+{
+  if ( ! s.empty() )
+    internal_assign(internal_toWideString(s));
+}
+#endif
+
+//----------------------------------------------------------------------
 FString::FString (const char s[])
 {
   if ( s )
@@ -937,12 +946,8 @@ auto FString::internal_toCharString (const std::wstring& s) const -> std::string
 }
 
 //----------------------------------------------------------------------
-auto FString::internal_toWideString (const std::string& s) const -> std::wstring
+auto FString::internal_toWideString (const char* src) const -> std::wstring
 {
-  if ( s.empty() )
-    return {};
-
-  auto src = s.c_str();
   auto state = std::mbstate_t();
   auto size = std::mbsrtowcs(nullptr, &src, 0, &state);
 
@@ -965,6 +970,26 @@ auto FString::internal_toWideString (const std::string& s) const -> std::wstring
   return {};
 }
 
+//----------------------------------------------------------------------
+auto FString::internal_toWideString (const std::string& s) const -> std::wstring
+{
+    if ( s.empty() )
+        return {};
+
+    return internal_toWideString(s.c_str());
+}
+
+//----------------------------------------------------------------------
+#if __cplusplus >= 201703L
+auto FString::internal_toWideString (const std::string_view& s) const -> std::wstring
+{
+    if ( s.empty() )
+        return {};
+
+    auto src = s.begin();
+    return internal_toWideString(src);
+}
+#endif
 
 // FString non-member operators
 //----------------------------------------------------------------------

--- a/final/util/fstring.h
+++ b/final/util/fstring.h
@@ -99,6 +99,9 @@ class FString
     FString (std::wstring&&);        // implicit conversion constructor
     FString (const wchar_t[]);       // implicit conversion constructor
     FString (const std::string&);    // implicit conversion constructor
+#if __cplusplus >= 201703L
+    FString (const std::string_view&);    // implicit conversion constructor
+#endif
     FString (const char[]);          // implicit conversion constructor
     FString (const UniChar&);        // implicit conversion constructor
     FString (const wchar_t);         // implicit conversion constructor
@@ -511,7 +514,11 @@ class FString
     // Methods
     void internal_assign (std::wstring);
     auto internal_toCharString (const std::wstring&) const -> std::string;
+    auto internal_toWideString (const char*) const -> std::wstring;
     auto internal_toWideString (const std::string&) const -> std::wstring;
+#if __cplusplus >= 201703L
+    auto internal_toWideString (const std::string_view&) const -> std::wstring;
+#endif
 
     // Data members
     std::wstring         string{};

--- a/final/widget/ftextview.h
+++ b/final/widget/ftextview.h
@@ -242,6 +242,14 @@ class FTextView : public FWidget
     void initLayout() override;
     void adjustSize() override;
 
+    // Inquiry
+    auto isHorizontallyScrollable() const -> bool;
+    auto isVerticallyScrollable() const -> bool;
+
+    // Accessors
+    auto getTextHeight() const -> std::size_t;
+    auto getTextWidth() const -> std::size_t;
+
   private:
     // Constants
     static constexpr auto UNINITIALIZED_ROW = static_cast<FTextViewList::size_type>(-1);
@@ -250,13 +258,7 @@ class FTextView : public FWidget
     // Using-declaration
     using KeyMap = std::unordered_map<FKey, std::function<void()>, EnumHash<FKey>>;
 
-    // Accessors
-    auto getTextHeight() const -> std::size_t;
-    auto getTextWidth() const -> std::size_t;
-
     // Inquiry
-    auto isHorizontallyScrollable() const -> bool;
-    auto isVerticallyScrollable() const -> bool;
     auto isWithinTextBounds (const FPoint&) const -> bool;
     auto isLowerRightResizeCorner (const FPoint&) const -> bool;
     auto hasWrongSelectionOrder() const -> bool;
@@ -371,7 +373,7 @@ inline auto FTextView::getColumns() const noexcept -> std::size_t
 
 //----------------------------------------------------------------------
 inline auto FTextView::getRows() const -> std::size_t
-{ return std::size_t(data.size()); }
+{ return data.size(); }
 
 //----------------------------------------------------------------------
 inline auto FTextView::getScrollPos() const -> FPoint


### PR DESCRIPTION
* add `string_view` constructor support to `FString`
* fix warning with unnecessary cast to `size_t`
* change some methods to protected so a widget that extends the TextView can reason about the scroll height/width. (in my case: in order to make the TextView always scroll down if it is already scrolled to the bottom extent upon append)