### PR TITLE
Undefined-behavior fix in scrollview

### DIFF
--- a/final/widget/fscrollview.cpp
+++ b/final/widget/fscrollview.cpp
@@ -697,7 +697,7 @@ void FScrollView::copy2area()
     return;
 
   auto* printarea = getCurrentPrintArea();
-  const auto* area_owner = printarea->getOwner<const FVTerm*>();
+  const auto* area_owner = printarea->getOwner<FVTerm*>();
   const auto* area_widget = static_cast<const FWidget*>(area_owner);
 
   const bool ignore_padding = getFlags().feature.ignore_padding;


### PR DESCRIPTION
Hello, i have compiled finalcut against ASan and UBSan along with other components for my application testing and get this report;

========================================6119==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x7c21fe4fc778 in realloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:85
    #1 0x7c21fdabda62 (/lib/x86_64-linux-gnu/libstdc++.so.6+0xbda62) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
    #2 0x7c21fdac93f0 (/lib/x86_64-linux-gnu/libstdc++.so.6+0xc93f0) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
    #3 0x7c21fdac9ea8 in __cxa_demangle (/lib/x86_64-linux-gnu/libstdc++.so.6+0xc9ea8) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
    #4 0x7c21fd22e5ba in __sanitizer::Symbolizer::Demangle(char const*) ../../../../src/libsanitizer/sanitizer_common/sanitizer_symbolizer_libcdep.cpp:169
    #5 0x7c21fd208280 in RenderText ../../../../src/libsanitizer/ubsan/ubsan_diag.cpp:199
    #6 0x7c21fd2099de in PrintMemorySnippet ../../../../src/libsanitizer/ubsan/ubsan_diag.cpp:329
    #7 0x7c21fd2099de in __ubsan::Diag::~Diag() ../../../../src/libsanitizer/ubsan/ubsan_diag.cpp:385
    #8 0x7c21fd20f617 in HandleDynamicTypeCacheMiss ../../../../src/libsanitizer/ubsan/ubsan_handlers_cxx.cpp:69
    #9 0x7c21fd20f90e in __ubsan_handle_dynamic_type_cache_miss ../../../../src/libsanitizer/ubsan/ubsan_handlers_cxx.cpp:87
    #10 0x64dc907e8eab in finalcut::cleanFData<finalcut::FVTerm const*>::type& finalcut::FVTerm::FTermArea::getOwner<finalcut::FVTerm const*>() const ../final/vterm/fvterm.h:448
    #11 0x64dc907cf90a in finalcut::FScrollView::copy2area() widget/fscrollview.cpp:700
    #12 0x64dc907c47f8 in finalcut::FScrollView::draw() widget/fscrollview.cpp:410
    #13 0x64dc905b5a8c in finalcut::FButtonGroup::draw() widget/fbuttongroup.cpp:334
    #14 0x64dc90997f1d in finalcut::FWidget::show() /home/ulak/repos/finalcut/final/fwidget.cpp:891
    #15 0x64dc909be48f in finalcut::FWidget::showChildWidgets() /home/ulak/repos/finalcut/final/fwidget.cpp:1779
    #16 0x64dc90998301 in finalcut::FWidget::show() /home/ulak/repos/finalcut/final/fwidget.cpp:894
    #17 0x64dc908b1871 in finalcut::FWindow::show() widget/fwindow.cpp:307
    #18 0x64dc902d89a7 in finalcut::FDialog::show() dialog/fdialog.cpp:172
    #19 0x64dc9020aafe in uOS::Logger::init(int, char**, std::optional<std::function<void ()> >) /home/ulak/repos/state-machine-framework/src/logger.cpp:170
    #20 0x64dc900b4191 in uOS::FW::init(int, char**, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/ulak/repos/state-machine-framework/src/uOS.cpp:69
    #21 0x64dc8fa58597 in main /home/ulak/repos/cms/main.cpp:8
    #22 0x7c21fce2a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #23 0x7c21fce2a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #24 0x64dc8fa58394 in _start (/home/ulak/repos/cms/build/cmsapp+0x204c394) (BuildId: e13f1b0ffb7c4dc381323116fec7e44d96bc21f9)

Its reported as a leak but actually an UB detected by UBSan (this happens when using ASan and UBSan together). What i understand is we are setting area owner as __FVTerm*__ but try to get it as __const FVTerm*__ via static_cast and this causes an UB in principle. No more reports generated after removing const in edit.
I don't think it would cause any runtime issue but wanted to fix it anyway. Its up to you for pull