### PR TITLE
Wrap CXXFLAGS test with double quotes in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@ AM_INIT_AUTOMAKE([-Wall -Werror foreign dist-zip])
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 AC_PROG_CC
 
-if test -z $CXXFLAGS
+if test -z "$CXXFLAGS"
 then
   CXXFLAGS="-O3"
 fi


### PR DESCRIPTION
Without the quotes when configuring with CXXFLAGS;

    ./configure CXXFLAGS='-g -O0' CPPFLAGS='-I$(top_srcdir)'

The test is interpreted as:

    test -z -g -O0

resulting in an error amongst the output like:

```
. . .
checking whether gcc understands -c and -o together... (cached) yes
./configure: line 6360: test: -g: binary operator expected
checking for g++... g++
checking whether the compiler supports GNU C++... yes
. . .
```
